### PR TITLE
show error message in case the author_name is not present

### DIFF
--- a/kindle2notion/parsing.py
+++ b/kindle2notion/parsing.py
@@ -65,9 +65,14 @@ def _add_parsed_items_to_books_dict(books: Dict, title: str, author: str, highli
 
 
 def _parse_raw_author_and_title(raw_clipping_list: List) -> Tuple[str, str]:
-    author = (re.findall(r'\(.*?\)', raw_clipping_list[0]))[-1]
-    author = author.removeprefix('(').removesuffix(')')
+    author = ""
     title = raw_clipping_list[0].replace(author, '').strip().replace(u'\ufeff', '').replace(' ()', '')
+    if ((re.findall(r'\(.*?\)', raw_clipping_list[0]))):
+        author = (re.findall(r'\(.*?\)', raw_clipping_list[0]))[0]
+        # author comes in the format '(Lastname, Firstname)'
+        author = author.removeprefix('(').removesuffix(')')
+    else:
+        print("For"+ title + ", no author was found in clippings file. You can manually edit your clippings file to add Author in the format: <Title: (Lastname, Firstname)>. For now continuing with empty author name")
     return author, title
 
 


### PR DESCRIPTION
* Adds a check for author name and shows error message but continues 
execution with empty author name

Resolves: #25