### PR TITLE
errors ignore changed to xmlcharrefreplace for special characters

### DIFF
--- a/kindle2notion/reading.py
+++ b/kindle2notion/reading.py
@@ -4,5 +4,5 @@ from pathlib import Path
 
 def read_raw_clippings(clippings_file_path: Path) -> str:
     raw_clippings_text = open(clippings_file_path, "r", encoding="utf-8-sig").read()
-    raw_clippings_text = raw_clippings_text.encode("ascii", errors="ignore").decode()
+    raw_clippings_text = raw_clippings_text.encode("ascii", errors="xmlcharrefreplace").decode()
     return raw_clippings_text


### PR DESCRIPTION
There was a problem with  non-english languages in Notion as I expressed in the Issue, 
Now it is working with other languages as much as I experienced. 