### PR TITLE
Add options for command line

### DIFF
--- a/kindle2notion/__main__.py
+++ b/kindle2notion/__main__.py
@@ -13,6 +13,11 @@ from kindle2notion.reading import read_raw_clippings
 @click.argument("notion_database_id")
 @click.argument("clippings_file")
 @click.option(
+    "--enable_location",
+    default=True,
+    help='Set to False if you don\'t want to see the "Location" and "Page" information in Notion.'
+)
+@click.option(
     "--enable_highlight_date",
     default=True,
     help='Set to False if you don\'t want to see the "Date Added" information in Notion.',
@@ -22,12 +27,20 @@ from kindle2notion.reading import read_raw_clippings
     default=True,
     help="Set to False if you don't want to store the book cover in Notion.",
 )
+@click.option(
+    "--separate_blocks",
+    default=False,
+    help='Set to True to separate each clipping into a separate quote block. Enabling this option significantly decreases upload speed.'
+)
+
 def main(
     notion_api_auth_token,
     notion_database_id,
     clippings_file,
+    enable_location,
     enable_highlight_date,
     enable_book_cover,
+    separate_blocks
 ):
     notion = notional.connect(auth=notion_api_auth_token)
     db = notion.databases.retrieve(notion_database_id)
@@ -44,10 +57,12 @@ def main(
         # Export all the contents in all_books into the Notion DB.
         export_to_notion(
             all_books,
+            enable_location,
             enable_highlight_date,
             enable_book_cover,
+            separate_blocks,
             notion_api_auth_token,
-            notion_database_id,
+            notion_database_id
         )
 
         with open("my_kindle_clippings.json", "w") as out_file:


### PR DESCRIPTION
Hi,
I added two more options `enable_location` and `separate_blocks` to give user greater control of the Notion output. Although enabling `separate_blocks` decreases upload speed, it improves readability and style.

FYI the other [kindle to notion project](https://github.com/arkalim/kindle-to-notion) styles clippings as block quotes without location information:

![image](https://user-images.githubusercontent.com/77399093/232841433-1412c253-04cf-408c-a926-d26500835fea.png)
